### PR TITLE
Fix for issue #7 - self.last_ts has the value of None which raises an exception in forecast.py

### DIFF
--- a/bin/user/forecast.py
+++ b/bin/user/forecast.py
@@ -1258,7 +1258,7 @@ class Forecast(StdService):
 #        sql = "select max(dateTime),issued_ts from %s where method = '%s'" % (table, method_id)
         r = dbm.getSql(sql)
         if r is None:
-            return None
+            return 0
         logdbg('%s: last forecast issued %s, requested %s' %
                (method_id,
                 weeutil.weeutil.timestamp_to_string(r[1]),


### PR DESCRIPTION
Caller puts the value of get_last_forecast() into a variable that is then compared against an integer. Use of None for non-existent databases causes an exception. Using zero instead means the update will occur.